### PR TITLE
feat: voting outliers endpoint

### DIFF
--- a/tipi_backend/api/endpoints/voting.py
+++ b/tipi_backend/api/endpoints/voting.py
@@ -2,12 +2,13 @@ import logging
 
 from flask_restx import Namespace, Resource
 
-from tipi_backend.api.business import get_voting
+from tipi_backend.api.business import get_voting, get_voting_outliers
+from tipi_backend.api.parsers import parser_voting_outliers
 
 
 log = logging.getLogger(__name__)
 
-ns = Namespace('voting', description='Operations related to votes')
+ns = Namespace("voting", description="Operations related to votes")
 
 
 @ns.route('/<initiative_id>')
@@ -24,4 +25,26 @@ class VotingItem(Resource):
             return get_voting(to_reference(initiative_id))
         except Exception as e:
             log.error(e)
-            return {'Error': 'No votings found'}, 404
+            return {"Error": "No votings found"}, 404
+
+
+ns = Namespace(
+    "voting-outliers",
+    description="Operations related to votes from outliers (people who vote differently from their group)",
+)
+
+
+@ns.route("/")
+@ns.expect(parser_voting_outliers)
+@ns.response(404, "Voting not found.")
+class VotingOutlierItem(Resource):
+    def get(self, exclude_group=None):
+        """Returns details of a voting."""
+        try:
+            log.info("Voting outliers called")
+            if exclude_group is None:
+                return get_voting_outliers()
+            return get_voting_outliers(exclude_group)
+        except Exception as e:
+            log.error(e)
+            return {"Error": "No voting outliers found"}, 404

--- a/tipi_backend/api/parsers.py
+++ b/tipi_backend/api/parsers.py
@@ -74,6 +74,9 @@ parser_footprint_by_parliamentarygroup = reqparse.RequestParser()
 parser_footprint_by_parliamentarygroup.add_argument('parliamentarygroup', type=str, required=True, location='args', help='To get the values, check out /parliamentary-groups')
 
 
+parser_voting_outliers = reqparse.RequestParser()
+parser_voting_outliers.add_argument('exclude_group', type=str, required=True, location='args', help='To get the values, check out /parliamentary-groups')
+
 class ParameterBag():
 
     EMPTY_VALUES = ['', None, []]

--- a/tipi_backend/api/types.py
+++ b/tipi_backend/api/types.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class VotingOutlier:
+    reference: str
+    title: str
+    group_votes: List[Dict[str, Any]]


### PR DESCRIPTION
* GET `/voting-outliers`: Will return all the votes where there has been an outlier and the parlamentary group that has had it:
* Example:
```
[ 
...
  {
    "reference": "122/000034",
    "title": "Votación de conjunto ...",
    "group_votes": [
      {
        "name": "GMx",
        "votes": {
          "yes": 7,
          "no": 1,
          "abstention": 0,
          "skip": 0
        }
      }
    ]
  },
...
]
```

* query param `exclude_group` If we want to exclude a group (for instance `Gmx` since it has many sub-parties in it)
